### PR TITLE
Implement WKWebView IOS

### DIFF
--- a/src/plotly.tsx
+++ b/src/plotly.tsx
@@ -108,7 +108,7 @@ const Plotly: React.FC<PlotlyProps> = props => {
         }
         </style>
     </head>
-    
+
     <body >
       <div id="chart" class="chart"></div>
       <pre id="error" class="error"></pre>
@@ -253,6 +253,7 @@ const Plotly: React.FC<PlotlyProps> = props => {
       onLoad={webviewLoaded}
       onMessage={onMessage}
       originWhitelist={['*']}
+      useWebKit={true}
     />
   );
 };


### PR DESCRIPTION
On iOS, we must include `useWebKit={true}` in the `WebView` to implement the new `WKWebView-backed`.

When ipa is deployed to Appstore, the developer recieve a warning message:

> ITMS-90809: Deprecated API Usage - Apple will stop accepting submissions of apps that use UIWebView APIs . See https://developer.apple.com/documentation/uikit/uiwebview for more information. 
