### PR TITLE
Set androidLayerType on WebView to prevent crash on Android 12

### DIFF
--- a/src/plotly.tsx
+++ b/src/plotly.tsx
@@ -107,7 +107,7 @@ const Plotly: React.FC<PlotlyProps> = (props) => {
         }
         </style>
     </head>
-    
+
     <body >
       <div id="chart" class="chart"></div>
       <pre id="error" class="error"></pre>
@@ -245,6 +245,7 @@ const Plotly: React.FC<PlotlyProps> = (props) => {
       onLoad={webviewLoaded}
       onMessage={onMessage}
       originWhitelist={['*']}
+      androidLayerType={'software'}
     />
   );
 };


### PR DESCRIPTION
### Issue

On Android 12 (I didn't test on Android 9), React Native Plotly always crashes with `null pointer dereference` issue (see [crash log](https://gist.github.com/endronk/2bc2eb2548b1b9ef8bee44724895711c)).

The same issue also occurred here (on Android 9): https://github.com/react-native-webview/react-native-webview/issues/1069

### Solution

The issue can be solved by setting `androidHardwareAccelerationDisabled` to true. However, that prop has been deprecated (see [this](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#androidhardwareaccelerationdisabled)) and we should use `androidLayerType` instead.

The above solution has been tested on Android phone as well as emulator.